### PR TITLE
Upgrading pyyaml to version 6.0 for removing vulnerabilities

### DIFF
--- a/scripts/dts/python-devicetree/setup.py
+++ b/scripts/dts/python-devicetree/setup.py
@@ -36,7 +36,7 @@ setuptools.setup(
         'Operating System :: Microsoft :: Windows',
     ],
     install_requires=[
-        'PyYAML>=5.1',
+        'PyYAML>=6.0',
     ],
     python_requires='>=3.6',
 )

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -8,7 +8,7 @@ pyelftools>=0.26
 
 # used by dts generation to parse binding YAMLs, also used by
 # twister to parse YAMLs, by west, zephyr_module,...
-PyYAML>=5.1
+PyYAML>=6.0
 
 # YAML validation. Used by zephyr_module.
 pykwalify


### PR DESCRIPTION
It updates the PyYaml version from 5.1 to 6. The 5.1 version has security vulnerabilities as described in these links:

https://vulners.com/github/GHSA-3PQX-4FQF-J49F
https://vulners.com/osv/OSV:PYSEC-2020-96
https://vulners.com/osv/OSV:PYSEC-2021-142

These vulnerabilities were found by running https://securityscorecards.dev/